### PR TITLE
Use the C# extension's ExternalAccess assembly

### DIFF
--- a/.github/memory/ARCHITECTURE.md
+++ b/.github/memory/ARCHITECTURE.md
@@ -21,6 +21,7 @@ The .NET Compiler Developer SDK is a VS Code extension for exploring Roslyn synt
 - The extension depends on `ms-dotnettools.csharp`; it does not start its own language server.
 - `csharpExtensionExports.ts` describes only the external C# extension exports consumed by this app.
 - `csharpExtensionLoadPaths` loads the packaged backend DLL into the C# language server.
+- The backend compiles against the C# extension's ExternalAccess API version and uses the ExternalAccess assembly supplied by the C# extension at runtime.
 - Backend handlers are stateless Compiler Developer SDK services bound to names in `Endpoints.cs`.
 
 ## Caching and Lazy Loading

--- a/.github/memory/CONVENTIONS.md
+++ b/.github/memory/CONVENTIONS.md
@@ -25,7 +25,7 @@ Formatting and standard language conventions are enforced by `.editorconfig`, Ty
 
 - Request handlers are stateless; document-derived state belongs in dedicated cache services.
 - Pin required transitive NuGet updates centrally in `Directory.Packages.props`.
-- Runtime backend dependencies must be copied into `dist` by `VscePrepublish`.
+- Runtime backend dependencies must be copied into `dist` by `VscePrepublish`, except assemblies supplied by the host C# extension, such as the Compiler Developer SDK ExternalAccess assembly.
 - Do not edit generated `dist/`, `out/`, `bin/`, or `obj/` artifacts.
 
 ## Errors and Logging

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <NoWarn>NU1507</NoWarn>
 
-    <MicrosoftCodeAnalysisVersion>5.7.0-1.26220.1</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>5.10.0-1.26352.10</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftCodeAnalysisVersion)" />

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ This extension depends on the [C# extension](https://marketplace.visualstudio.co
 
 ## Release Notes
 
+### 0.4.8
+
+* Update Roslyn dependencies to match the C# extension.
+* Use the Compiler Developer SDK ExternalAccess assembly supplied by the C# extension instead of packaging a separate copy.
+
 ### 0.4.7
 
 * Update the extension backend to target .NET 10 and newer Roslyn dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "net-compiler-developer-sdk",
-    "version": "0.4.7",
+    "version": "0.4.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "net-compiler-developer-sdk",
-            "version": "0.4.7",
+            "version": "0.4.8",
             "dependencies": {
                 "vscode-languageclient": "^9.0.1"
             },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": ".NET Compiler Developer SDK",
     "publisher": "333fred",
     "description": "VS Code extension for working with and on the Roslyn compiler.",
-    "version": "0.4.7",
+    "version": "0.4.8",
     "icon": "images/roslyn_icon_color.png",
     "repository": {
         "type": "git",

--- a/src/Microsoft.CodeAnalysis.CompilerDeveloperSdk/Microsoft.CodeAnalysis.CompilerDeveloperSdk.csproj
+++ b/src/Microsoft.CodeAnalysis.CompilerDeveloperSdk/Microsoft.CodeAnalysis.CompilerDeveloperSdk.csproj
@@ -13,21 +13,16 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" ExcludeAssets="runtime" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.CompilerDeveloperSdk" ExcludeAssets="runtime" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.CompilerDeveloperSdk" ExcludeAssets="runtime" />
     <PackageReference Include="ICSharpCode.Decompiler" ExcludeAssets="runtime" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <Target Name="VscePrepublish"
-    DependsOnTargets="Build"
-    Inputs="$(TargetPath);
-            $(PkgMicrosoft_CodeAnalysis_ExternalAccess_CompilerDeveloperSDK)
-            $(PkgICSharpCode_Decompiler)"
-    Outputs="$(MSBuildThisFileDirectory)..\..\dist\Microsoft.CodeAnalysis.ExternalAccess.CompilerDeveloperSDK.dll;
-             $(MSBuildThisFileDirectory)..\..\dist\Microsoft.CodeAnalysis.CompilerDeveloperSdk.dll
-             $(MSBuildThisFileDirectory)..\..\dist\ICSharpCode.Decompiler.dll">
+  <Target Name="VscePrepublish" DependsOnTargets="Build">
+
+    <Delete Files="$(MSBuildThisFileDirectory)..\..\dist\Microsoft.CodeAnalysis.ExternalAccess.CompilerDeveloperSDK.dll" />
 
     <Copy
-        SourceFiles="$(TargetPath);$(PkgMicrosoft_CodeAnalysis_ExternalAccess_CompilerDeveloperSDK)\lib\$(TargetFramework)\Microsoft.CodeAnalysis.ExternalAccess.CompilerDeveloperSDK.dll;$(PkgICSharpCode_Decompiler)\lib\netstandard2.0\ICSharpCode.Decompiler.dll"
+        SourceFiles="$(TargetPath);$(PkgICSharpCode_Decompiler)\lib\netstandard2.0\ICSharpCode.Decompiler.dll"
         DestinationFolder="$(MSBuildThisFileDirectory)..\..\dist">
     </Copy>
   </Target>


### PR DESCRIPTION
This pull request addresses issue #21 by implementing two key changes:

- Updated the Roslyn/EA reference to version `5.10.0-1.26352.10` in `Directory.Packages.props`.
- Removed the EA assembly from the `dist` directory during packaging to prevent conflicts, ensuring that the C# extension's version is used instead.

Additionally, the patch version has been bumped to `0.4.8`, and the changelog has been updated accordingly. All validations, including backend build, ESLint, and VSIX packaging, have passed successfully.